### PR TITLE
backend: add option to filter items by title

### DIFF
--- a/backend/routes/api/items.js
+++ b/backend/routes/api/items.js
@@ -71,6 +71,10 @@ router.get("/", auth.optional, function(req, res, next) {
         query._id = { $in: [] };
       }
 
+      if (req.query.title) {
+        query.title = { "$regex": req.query.title, "$options": "i" };
+      }
+
       return Promise.all([
         Item.find(query)
           .limit(Number(limit))

--- a/frontend/src/agent.js
+++ b/frontend/src/agent.js
@@ -54,6 +54,7 @@ const limit = (count, p) => `limit=${count}&offset=${p ? p * count : 0}`;
 const omitSlug = (item) => Object.assign({}, item, { slug: undefined });
 const Items = {
   all: (page) => requests.get(`/items?${limit(1000, page)}`),
+  byTitle: (title, page) => requests.get(`/items?title=${title}&${limit(1000, page)}`),
   bySeller: (seller, page) =>
     requests.get(`/items?seller=${encode(seller)}&${limit(500, page)}`),
   byTag: (tag, page) =>


### PR DESCRIPTION
# Description

Add option to filter items by title in the GET items api endpoint, using a query parameter 'title'.